### PR TITLE
Support standard Postgres environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,7 +122,25 @@ func main() {
 			config.Host = "localhost"
 		}
 
-		// override if passed-in
+		// apply defaults from Postgres environment variables, but allow
+		// them to be overridden in the next step
+		if os.Getenv("PGUSER") != "" {
+			config.Username = os.Getenv("PGUSER")
+		}
+		if os.Getenv("PGPASSWORD") != "" {
+			config.Password = os.Getenv("PGPASSWORD")
+		}
+		if os.Getenv("PGDATABASE") != "" {
+			config.Database = os.Getenv("PGDATABASE")
+		}
+		if os.Getenv("PGHOST") != "" {
+			config.Host = os.Getenv("PGHOST")
+		}
+		if os.Getenv("PGPORT") != "" {
+			config.Port, _ = strconv.Atoi(os.Getenv("PGPORT"))
+		}
+
+		// override if passed-in from the CLI or via environment variables
 		if c.String("username") != "" {
 			config.Username = c.String("username")
 		}

--- a/main.go
+++ b/main.go
@@ -113,15 +113,6 @@ func main() {
 			fmt.Println("error reading config file: ", err)
 		}
 
-		// apply some defaults
-		if config.Port == 0 {
-			config.Port = 5432
-		}
-
-		if config.Host == "" {
-			config.Host = "localhost"
-		}
-
 		// apply defaults from Postgres environment variables, but allow
 		// them to be overridden in the next step
 		if os.Getenv("PGUSER") != "" {
@@ -138,6 +129,14 @@ func main() {
 		}
 		if os.Getenv("PGPORT") != "" {
 			config.Port, _ = strconv.Atoi(os.Getenv("PGPORT"))
+		}
+
+		// apply some other, sane defaults
+		if config.Port == 0 {
+			config.Port = 5432
+		}
+		if config.Host == "" {
+			config.Host = "localhost"
 		}
 
 		// override if passed-in from the CLI or via environment variables

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -178,9 +178,9 @@ func Version(c *Config) (int, error) {
 
 	// if the table doesn't exist, we're at version -1
 	var hasTable bool
-	err = db.QueryRow("SELECT true FROM pg_catalog.pg_tables WHERE tablename='schema_migrations'").Scan(&hasTable)
+	err = db.QueryRow("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_tables WHERE tablename='schema_migrations')").Scan(&hasTable)
 	if hasTable != true {
-		return -1, nil
+		return -1, err
 	}
 
 	var version int

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -333,6 +333,7 @@ func sqlConnectionString(c *Config) string {
 		" dbname='", c.Database, "'",
 		" password='", c.Password, "'",
 		" host='", c.Host, "'",
+		" port=", c.Port,
 		" sslmode=", "disable")
 }
 


### PR DESCRIPTION
This change should make it easier to use pgmgr alongside other Postgres tools, as it will use the standard `PGHOST`, `PGUSERNAME`, `PGPASSWORD`, `PGPORT`, and `PGDATABASE` variables to configure itself if other configuration is absent.

Fixes #3.