### PR TITLE
Config refactor

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"os"
-	"github.com/rnubel/pgmgr/pgmgr"
-	"github.com/codegangsta/cli"
 	"fmt"
+	"github.com/codegangsta/cli"
+	"github.com/rnubel/pgmgr/pgmgr"
+	"os"
 )
 
-func displayErrorOrMessage(err error, args... interface{}) {
+func displayErrorOrMessage(err error, args ...interface{}) {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error: ", err)
 		os.Exit(1)
@@ -29,71 +29,71 @@ func main() {
 	config := &pgmgr.Config{}
 	app := cli.NewApp()
 
-	app.Name  = "pgmgr"
+	app.Name = "pgmgr"
 	app.Usage = "manage your app's Postgres database"
 	app.Version = "0.0.1"
 
 	s := make([]string, 0)
 
-	app.Flags = []cli.Flag {
+	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "config-file, c",
-			Value: ".pgmgr.json",
-			Usage: "set the path to the JSON configuration file specifying your DB parameters",
+			Name:   "config-file, c",
+			Value:  ".pgmgr.json",
+			Usage:  "set the path to the JSON configuration file specifying your DB parameters",
 			EnvVar: "PGMGR_CONFIG_FILE",
 		},
 		cli.StringFlag{
-			Name:  "database, d",
-			Value: "",
-			Usage: "the database name which pgmgr will connect to or try to create",
+			Name:   "database, d",
+			Value:  "",
+			Usage:  "the database name which pgmgr will connect to or try to create",
 			EnvVar: "PGMGR_DATABASE",
 		},
 		cli.StringFlag{
-			Name:  "username, u",
-			Value: "",
-			Usage: "the username which pgmgr will connect with",
+			Name:   "username, u",
+			Value:  "",
+			Usage:  "the username which pgmgr will connect with",
 			EnvVar: "PGMGR_USERNAME",
 		},
 		cli.StringFlag{
-			Name:  "password, P",
-			Value: "",
-			Usage: "the password which pgmgr will connect with",
+			Name:   "password, P",
+			Value:  "",
+			Usage:  "the password which pgmgr will connect with",
 			EnvVar: "PGMGR_PASSWORD",
 		},
 		cli.StringFlag{
-			Name:  "host, H",
-			Value: "",
-			Usage: "the host which pgmgr will connect to",
+			Name:   "host, H",
+			Value:  "",
+			Usage:  "the host which pgmgr will connect to",
 			EnvVar: "PGMGR_HOST",
 		},
 		cli.IntFlag{
-			Name:  "port, p",
-			Value: 0,
-			Usage: "the port which pgmgr will connect to",
+			Name:   "port, p",
+			Value:  0,
+			Usage:  "the port which pgmgr will connect to",
 			EnvVar: "PGMGR_PORT",
 		},
 		cli.StringFlag{
-			Name: "url",
-			Value: "",
-			Usage: "connection URL or DSN containing connection info; will override the other params if given",
+			Name:   "url",
+			Value:  "",
+			Usage:  "connection URL or DSN containing connection info; will override the other params if given",
 			EnvVar: "PGMGR_URL",
 		},
 		cli.StringFlag{
-			Name:  "dump-file",
-			Value: "",
-			Usage: "where to dump or load the database structure and contents to or from",
+			Name:   "dump-file",
+			Value:  "",
+			Usage:  "where to dump or load the database structure and contents to or from",
 			EnvVar: "PGMGR_DUMP_FILE",
 		},
 		cli.StringFlag{
-			Name:  "migration-folder",
-			Value: "",
-			Usage: "folder containing the migrations to apply",
+			Name:   "migration-folder",
+			Value:  "",
+			Usage:  "folder containing the migrations to apply",
 			EnvVar: "PGMGR_MIGRATION_FOLDER",
 		},
 		cli.StringSliceFlag{
-			Name:  "seed-tables",
-			Value: (*cli.StringSlice)(&s),
-			Usage: "list of tables (or globs matching table names) to dump the data of",
+			Name:   "seed-tables",
+			Value:  (*cli.StringSlice)(&s),
+			Usage:  "list of tables (or globs matching table names) to dump the data of",
 			EnvVar: "PGMGR_SEED_TABLES",
 		},
 	}
@@ -108,7 +108,7 @@ func main() {
 
 	app.Commands = []cli.Command{
 		{
-			Name: "migration",
+			Name:  "migration",
 			Usage: "generates a new migration with the given name",
 			Action: func(c *cli.Context) {
 				if len(c.Args()) == 0 {
@@ -119,32 +119,32 @@ func main() {
 			},
 		},
 		{
-			Name: "config",
+			Name:  "config",
 			Usage: "displays the current configuration as seen by pgmgr",
 			Action: func(c *cli.Context) {
 				fmt.Printf("%+v\n", config)
 			},
 		},
 		{
-			Name: "db",
+			Name:  "db",
 			Usage: "manage your database. use 'pgmgr db help' for more info",
 			Subcommands: []cli.Command{
 				{
-					Name: "create",
+					Name:  "create",
 					Usage: "creates the database if it doesn't exist",
 					Action: func(c *cli.Context) {
 						displayErrorOrMessage(pgmgr.Create(config), "Database", config.Database, "created successfully.")
 					},
 				},
 				{
-					Name: "drop",
+					Name:  "drop",
 					Usage: "drops the database (all sessions must be disconnected first. this command does not force it)",
 					Action: func(c *cli.Context) {
 						displayErrorOrMessage(pgmgr.Drop(config), "Database", config.Database, "dropped successfully.")
 					},
 				},
 				{
-					Name: "dump",
+					Name:  "dump",
 					Usage: "dumps the database schema and contents to the dump file (see --dump-file)",
 					Action: func(c *cli.Context) {
 						err := pgmgr.Dump(config)
@@ -152,7 +152,7 @@ func main() {
 					},
 				},
 				{
-					Name: "load",
+					Name:  "load",
 					Usage: "loads the database schema and contents from the dump file (see --dump-file)",
 					Action: func(c *cli.Context) {
 						err := pgmgr.Load(config)
@@ -161,14 +161,14 @@ func main() {
 					},
 				},
 				{
-					Name: "version",
+					Name:  "version",
 					Usage: "returns the current schema version",
 					Action: func(c *cli.Context) {
 						displayVersion(config)
 					},
 				},
 				{
-					Name: "migrate",
+					Name:  "migrate",
 					Usage: "applies any un-applied migrations in the migration folder (see --migration-folder)",
 					Action: func(c *cli.Context) {
 						err := pgmgr.Migrate(config)
@@ -179,7 +179,7 @@ func main() {
 					},
 				},
 				{
-					Name: "rollback",
+					Name:  "rollback",
 					Usage: "rolls back the latest migration",
 					Action: func(c *cli.Context) {
 						pgmgr.Rollback(config)

--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -1,0 +1,111 @@
+package pgmgr
+
+import (
+	"os"
+	"io/ioutil"
+	"encoding/json"
+	"github.com/codegangsta/cli"
+	"regexp"
+	"strconv"
+	"fmt"
+)
+
+type Config struct {
+	// connection
+	Username string
+	Password string
+	Database string
+	Host     string
+	Port     int
+	Url      string
+
+	// filepaths
+	DumpFile        string	`json:"dump-file"`
+	MigrationFolder string	`json:"migration-folder"`
+
+	// options
+	SeedTables	[]string	`json:"seed-tables"`
+}
+
+func LoadConfig(config *Config, ctx *cli.Context) {
+	// load configuration from file first; then override with
+	// flags or env vars if they're present.
+	configFile := ctx.String("config-file")
+	contents, err := ioutil.ReadFile(configFile)
+	if err == nil {
+		json.Unmarshal(contents, &config)
+	} else {
+		fmt.Println("error reading config file: ", err)
+	}
+
+	// apply defaults from Postgres environment variables, but allow
+	// them to be overridden in the next step
+	if os.Getenv("PGUSER") != "" {
+		config.Username = os.Getenv("PGUSER")
+	}
+	if os.Getenv("PGPASSWORD") != "" {
+		config.Password = os.Getenv("PGPASSWORD")
+	}
+	if os.Getenv("PGDATABASE") != "" {
+		config.Database = os.Getenv("PGDATABASE")
+	}
+	if os.Getenv("PGHOST") != "" {
+		config.Host = os.Getenv("PGHOST")
+	}
+	if os.Getenv("PGPORT") != "" {
+		config.Port, _ = strconv.Atoi(os.Getenv("PGPORT"))
+	}
+
+	// apply some other, sane defaults
+	if config.Port == 0 {
+		config.Port = 5432
+	}
+	if config.Host == "" {
+		config.Host = "localhost"
+	}
+
+	// override if passed-in from the CLI or via environment variables
+	if ctx.String("username") != "" {
+		config.Username = ctx.String("username")
+	}
+	if ctx.String("password") != "" {
+		config.Password = ctx.String("password")
+	}
+	if ctx.String("database") != "" {
+		config.Database = ctx.String("database")
+	}
+	if ctx.String("host") != "" {
+		config.Host = ctx.String("host")
+	}
+	if ctx.Int("port") != 0  {
+		config.Port = ctx.Int("port")
+	}
+	if ctx.String("url") != "" {
+		config.Url = ctx.String("url")
+	}
+
+	if config.Url != "" { // TODO: move this into pgmgr, probably?
+		// parse the DSN and populate the other configuration values. Some of the pg commands
+		// accept a DSN parameter, but not all, so this will help unify things.
+		r := regexp.MustCompile("^postgres://(.*)@(.*):([0-9]+)/([a-zA-Z0-9_-]+)")
+		m := r.FindStringSubmatch(config.Url)
+		if len(m) > 0 {
+			config.Username = m[1]
+			config.Host = m[2]
+			config.Port, _ = strconv.Atoi(m[3])
+			config.Database = m[4]
+		} else {
+			println("Could not parse DSN:  ", config.Url, " using regex ", r.String())
+		}
+	}
+
+	if ctx.String("dump-file") != "" {
+		config.DumpFile = ctx.String("dump-file")
+	}
+	if ctx.String("migration-folder") != "" {
+		config.MigrationFolder = ctx.String("migration-folder")
+	}
+	if ctx.StringSlice("seed-tables") != nil && len(ctx.StringSlice("seed-tables")) > 0 {
+		config.SeedTables = ctx.StringSlice("seed-tables")
+	}
+}

--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -1,13 +1,13 @@
 package pgmgr
 
 import (
-	"os"
-	"io/ioutil"
 	"encoding/json"
+	"fmt"
 	"github.com/codegangsta/cli"
+	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
-	"fmt"
 )
 
 type Config struct {
@@ -20,11 +20,11 @@ type Config struct {
 	Url      string
 
 	// filepaths
-	DumpFile        string	`json:"dump-file"`
-	MigrationFolder string	`json:"migration-folder"`
+	DumpFile        string `json:"dump-file"`
+	MigrationFolder string `json:"migration-folder"`
 
 	// options
-	SeedTables	[]string	`json:"seed-tables"`
+	SeedTables []string `json:"seed-tables"`
 }
 
 func LoadConfig(config *Config, ctx *cli.Context) {
@@ -99,7 +99,7 @@ func (config *Config) applyArguments(ctx *cli.Context) {
 	if ctx.String("host") != "" {
 		config.Host = ctx.String("host")
 	}
-	if ctx.Int("port") != 0  {
+	if ctx.Int("port") != 0 {
 		config.Port = ctx.Int("port")
 	}
 	if ctx.String("url") != "" {

--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -3,12 +3,19 @@ package pgmgr
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codegangsta/cli"
 	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
 )
+
+// Something that stores key-value pairs of various types,
+// e.g., cli.Context.
+type ArgumentContext interface {
+	String(string) string
+	Int(string) int
+	StringSlice(string) []string
+}
 
 type Config struct {
 	// connection
@@ -27,7 +34,7 @@ type Config struct {
 	SeedTables []string `json:"seed-tables"`
 }
 
-func LoadConfig(config *Config, ctx *cli.Context) {
+func LoadConfig(config *Config, ctx ArgumentContext) {
 	// load configuration from file first; then override with
 	// flags or env vars if they're present.
 	configFile := ctx.String("config-file")
@@ -86,7 +93,7 @@ func (config *Config) applyDefaults() {
 	}
 }
 
-func (config *Config) applyArguments(ctx *cli.Context) {
+func (config *Config) applyArguments(ctx ArgumentContext) {
 	if ctx.String("username") != "" {
 		config.Username = ctx.String("username")
 	}

--- a/pgmgr/config_test.go
+++ b/pgmgr/config_test.go
@@ -1,0 +1,95 @@
+package pgmgr
+
+import (
+	"testing"
+	"../pgmgr"
+	"os"
+)
+
+// create a mock to replace cli.Context
+type TestContext struct {
+	StringVals map[string] string
+	IntVals map[string] int
+	StringSliceVals map[string] []string
+}
+func (t *TestContext) String(key string) string {
+	return t.StringVals[key]
+}
+func (t *TestContext) Int(key string) int {
+	return t.IntVals[key]
+}
+func (t *TestContext) StringSlice(key string) []string {
+	return t.StringSliceVals[key]
+}
+
+func TestDefaults(t *testing.T) {
+	c := &pgmgr.Config{}
+
+	pgmgr.LoadConfig(c, &TestContext{})
+
+	if c.Port != 5432 {
+		t.Fatal("config's port should default to 5432")
+	}
+
+	if c.Host != "localhost" {
+		t.Fatal("config's host should default to localhost, but was ", c.Host)
+	}
+}
+
+func TestOverlays(t *testing.T) {
+	c := &pgmgr.Config{}
+	ctx := &TestContext{IntVals: make(map[string]int)}
+
+	// should prefer the value from ctx, since
+	// it was passed-in explictly at runtime
+	c.Port = 123
+	ctx.IntVals["port"] = 456
+	os.Setenv("PGPORT", "789")
+
+  pgmgr.LoadConfig(c, ctx)
+
+	if c.Port != 456 {
+		t.Fatal("config's port should come from the context, but was", c.Port)
+	}
+
+	// reset
+	c = &pgmgr.Config{}
+	ctx = &TestContext{IntVals: make(map[string]int)}
+
+	// should prefer the value from PGPORT, since
+	// nothing was passed-in at runtime
+	c.Port = 123
+	os.Setenv("PGPORT", "789")
+
+  pgmgr.LoadConfig(c, ctx)
+
+	if c.Port != 789 {
+		t.Fatal("config's port should come from PGPORT, but was", c.Port)
+	}
+
+	// reset
+	c = &pgmgr.Config{}
+	ctx = &TestContext{IntVals: make(map[string]int)}
+
+	// should prefer the value in the struct, since
+	// nothing else is given
+	c.Port = 123
+	os.Setenv("PGPORT", "")
+
+  pgmgr.LoadConfig(c, ctx)
+
+	if c.Port != 123 {
+		t.Fatal("config's port should not change, but was", c.Port)
+	}
+}
+
+func TestURL (t *testing.T) {
+	c := &pgmgr.Config{}
+	c.Url = "postgres://foo@bar:5431/testdb"
+
+	pgmgr.LoadConfig(c, &TestContext{})
+
+	if c.Username != "foo" || c.Host != "bar" || c.Port != 5431 || c.Database != "testdb" {
+		t.Fatal("config did not populate itself from the given URL:", c)
+	}
+}

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -16,23 +16,6 @@ import (
 	"time"
 )
 
-type Config struct {
-	// connection
-	Username string
-	Password string
-	Database string
-	Host     string
-	Port     int
-	Url      string
-
-	// filepaths
-	DumpFile        string	`json:"dump-file"`
-	MigrationFolder string	`json:"migration-folder"`
-
-	// options
-	SeedTables	[]string	`json:"seed-tables"`
-}
-
 type Migration struct {
 	Filename string
 	Version  int

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -47,8 +47,8 @@ func Dump(c *Config) error {
 	// then selected data...
 	args := []string{c.Database, "--data-only"}
 	if len(c.SeedTables) > 0 {
-		for _, table := range(c.SeedTables) {
-		  println("pulling data for", table)
+		for _, table := range c.SeedTables {
+			println("pulling data for", table)
 			args = append(args, "-t", table)
 		}
 	}
@@ -60,7 +60,7 @@ func Dump(c *Config) error {
 	}
 
 	// and combine into one file.
-	file, err := os.OpenFile(c.DumpFile, os.O_CREATE | os.O_TRUNC | os.O_RDWR, 0600)
+	file, err := os.OpenFile(c.DumpFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0600)
 	if err != nil {
 		return err
 	}
@@ -99,11 +99,11 @@ func Migrate(c *Config) error {
 			if err = applyMigration(c, m, UP); err != nil { // halt the migration process and return the error.
 				fmt.Println(err)
 				fmt.Println("")
-			  fmt.Println("ERROR! Aborting the migration process.")
+				fmt.Println("ERROR! Aborting the migration process.")
 				return err
 			}
 
-			fmt.Println("== Completed in", time.Now().Sub(t0).Nanoseconds() / 1e6, "ms ==")
+			fmt.Println("== Completed in", time.Now().Sub(t0).Nanoseconds()/1e6, "ms ==")
 			appliedAny = true
 		}
 	}
@@ -143,7 +143,7 @@ func Rollback(c *Config) error {
 		return err
 	}
 
-	fmt.Println("== Completed in", time.Now().Sub(t0).Nanoseconds() / 1e6, "ms ==")
+	fmt.Println("== Completed in", time.Now().Sub(t0).Nanoseconds()/1e6, "ms ==")
 
 	return nil
 }
@@ -188,11 +188,10 @@ func Initialize(c *Config) error {
 	return nil
 }
 
-
 // Creates new, blank migration files.
 func CreateMigration(c *Config, name string) error {
 	version := generateVersion()
-	up_filepath   := filepath.Join(c.MigrationFolder, fmt.Sprint(version, "_", name, ".up.sql"))
+	up_filepath := filepath.Join(c.MigrationFolder, fmt.Sprint(version, "_", name, ".up.sql"))
 	down_filepath := filepath.Join(c.MigrationFolder, fmt.Sprint(version, "_", name, ".down.sql"))
 
 	err := ioutil.WriteFile(up_filepath, []byte(`-- Migration goes here.`), 0644)

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -1,21 +1,21 @@
 package pgmgr
 
 import (
-	"testing"
 	"../pgmgr"
-	"os/exec"
-	"io/ioutil"
-	"strings"
-	"time"
 	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
 )
 
 func globalConfig() *pgmgr.Config {
 	return &pgmgr.Config{
-		Database: "testdb",
-		Host:			"localhost",
-		Port:			5432,
-		DumpFile: "/tmp/dump.sql",
+		Database:        "testdb",
+		Host:            "localhost",
+		Port:            5432,
+		DumpFile:        "/tmp/dump.sql",
 		MigrationFolder: "/tmp/migrations/",
 	}
 }
@@ -52,10 +52,10 @@ func TestDrop(t *testing.T) {
 func TestDump(t *testing.T) {
 	testSh(t, "dropdb", []string{"testdb"})
 	testSh(t, "createdb", []string{"testdb"})
-	testSh(t, "psql", []string{"-d", "testdb", "-c","CREATE TABLE bars (bar_id INTEGER);"})
-	testSh(t, "psql", []string{"-d", "testdb", "-c","INSERT INTO bars (bar_id) VALUES (123), (456);"})
-	testSh(t, "psql", []string{"-d", "testdb", "-c","CREATE TABLE foos (foo_id INTEGER);"})
-	testSh(t, "psql", []string{"-d", "testdb", "-c","INSERT INTO foos (foo_id) VALUES (789);"})
+	testSh(t, "psql", []string{"-d", "testdb", "-c", "CREATE TABLE bars (bar_id INTEGER);"})
+	testSh(t, "psql", []string{"-d", "testdb", "-c", "INSERT INTO bars (bar_id) VALUES (123), (456);"})
+	testSh(t, "psql", []string{"-d", "testdb", "-c", "CREATE TABLE foos (foo_id INTEGER);"})
+	testSh(t, "psql", []string{"-d", "testdb", "-c", "INSERT INTO foos (foo_id) VALUES (789);"})
 
 	c := globalConfig()
 	err := pgmgr.Dump(c)
@@ -118,7 +118,7 @@ func TestLoad(t *testing.T) {
 		t.Fatal("Could not load database from file")
 	}
 
-	err = testSh(t, "psql", []string{"-d", "testdb", "-c","SELECT * FROM foos;"})
+	err = testSh(t, "psql", []string{"-d", "testdb", "-c", "SELECT * FROM foos;"})
 	if err != nil {
 		t.Log(err)
 		t.Fatal("Could not query the table; schema didn't load, probably")
@@ -182,7 +182,7 @@ func TestMigrate(t *testing.T) {
 		t.Fatal("Running migrations again was not idempotent!")
 	}
 
-	err = testSh(t, "psql", []string{"-d", "testdb", "-c","SELECT * FROM foos;"})
+	err = testSh(t, "psql", []string{"-d", "testdb", "-c", "SELECT * FROM foos;"})
 	if err != nil {
 		t.Log(err)
 		t.Fatal("Could not query the table; migration didn't apply, probably")
@@ -200,7 +200,7 @@ func TestMigrate(t *testing.T) {
 		t.Fatal("Could not apply second migration!")
 	}
 
-	err = testSh(t, "psql", []string{"-d", "testdb", "-c","SELECT * FROM bars;"})
+	err = testSh(t, "psql", []string{"-d", "testdb", "-c", "SELECT * FROM bars;"})
 	if err != nil {
 		t.Log(err)
 		t.Fatal("Could not query the table; second migration didn't apply, probably")
@@ -209,7 +209,7 @@ func TestMigrate(t *testing.T) {
 	// rollback the initial migration, since it has the latest version
 	err = pgmgr.Rollback(globalConfig())
 
-	err = testSh(t, "psql", []string{"-d", "testdb", "-c","SELECT * FROM foos;"})
+	err = testSh(t, "psql", []string{"-d", "testdb", "-c", "SELECT * FROM foos;"})
 	if err == nil {
 		t.Log(err)
 		t.Fatal("Could query the table; migration didn't downgrade")


### PR DESCRIPTION
Having all of the configuration loading in main.go makes it hard to test. This moves it into the `pgmgr` package, which will make it easier to add tests for.