### PR TITLE
Support Rails-style version format and column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,20 @@ variable `PGMGR_CONFIG_FILE`. It should look something like:
   "database": "testdb",
   "migration-folder": "db/migrate",
   "dump-file": "db/dump.sql",
+  "column-type": "integer",
+  "format": "unix",
   "seed-tables": [ "foos", "bars" ]
 }
 ```
 
+The `column-type` option can be `integer` or `string`, and determines
+the type of the `schema_migrations.version` column. The `string` column
+type will store versions as `CHARACTER VARYING (255)`.
+
+The `format` option can be `unix` or `datetime`. The `unix` format is
+the integer epoch time; the `datetime` uses versions similar to ActiveRecord,
+such as `20150910120933`. In order to use the `datetime` format, you must
+also use the `string` column type.
 
 ### Environment variables
 

--- a/main.go
+++ b/main.go
@@ -102,9 +102,7 @@ func main() {
 	app.Before = func(c *cli.Context) error {
 		// TODO: LoadConfig should validate some basic properties of a valid config,
 		// like that the database name is set, and return an error if not.
-		pgmgr.LoadConfig(config, c)
-
-		return nil
+		return pgmgr.LoadConfig(config, c)
 	}
 
 	app.Commands = []cli.Command{

--- a/main.go
+++ b/main.go
@@ -100,8 +100,6 @@ func main() {
 	}
 
 	app.Before = func(c *cli.Context) error {
-		// TODO: LoadConfig should validate some basic properties of a valid config,
-		// like that the database name is set, and return an error if not.
 		return pgmgr.LoadConfig(config, c)
 	}
 

--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	// options
 	SeedTables []string `json:"seed-tables"`
 	ColumnType string   `json:"column-type"`
-	Format     string   `json:"format"`
+	Format     string
 }
 
 // LoadConfig reads the config file, applies CLI arguments as

--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -2,6 +2,7 @@ package pgmgr
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -37,9 +38,9 @@ type Config struct {
 	Format     string   `json:"format"`
 }
 
-// LoadConfig reads the config file and applies CLI arguments as
-// overrides.
-func LoadConfig(config *Config, ctx argumentContext) {
+// LoadConfig reads the config file, applies CLI arguments as
+// overrides, and returns an error if the configuration is invalid.
+func LoadConfig(config *Config, ctx argumentContext) error {
 	// load configuration from file first; then override with
 	// flags or env vars if they're present.
 	configFile := ctx.String("config-file")
@@ -60,6 +61,8 @@ func LoadConfig(config *Config, ctx argumentContext) {
 	if config.URL != "" {
 		config.overrideFromURL()
 	}
+
+	return config.validate()
 }
 
 func (config *Config) populateFromFile(configFile string) {
@@ -147,4 +150,20 @@ func (config *Config) overrideFromURL() {
 	} else {
 		println("Could not parse DSN:  ", config.URL, " using regex ", r.String())
 	}
+}
+
+func (config *Config) validate() error {
+	if config.ColumnType != "integer" && config.ColumnType != "string" {
+		return errors.New(`ColumnType must be "integer" or "string"`)
+	}
+
+	if config.Format != "unix" && config.Format != "datetime" {
+		return errors.New(`Format must be "unix" or "datetime"`)
+	}
+
+	if config.Format == "datetime" && config.ColumnType != "string" {
+		return errors.New(`ColumnType must be "string" if Format is "datetime"`)
+	}
+
+	return nil
 }

--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -33,6 +33,8 @@ type Config struct {
 
 	// options
 	SeedTables []string `json:"seed-tables"`
+	ColumnType string   `json:"column-type"`
+	Format     string   `json:"format"`
 }
 
 // LoadConfig reads the config file and applies CLI arguments as
@@ -93,6 +95,12 @@ func (config *Config) applyDefaults() {
 	}
 	if config.Host == "" {
 		config.Host = "localhost"
+	}
+	if config.Format == "" {
+		config.Format = "unix"
+	}
+	if config.ColumnType == "" {
+		config.ColumnType = "integer"
 	}
 }
 

--- a/pgmgr/config_test.go
+++ b/pgmgr/config_test.go
@@ -36,6 +36,14 @@ func TestDefaults(t *testing.T) {
 	if c.Host != "localhost" {
 		t.Fatal("config's host should default to localhost, but was ", c.Host)
 	}
+
+	if c.ColumnType != "integer" {
+		t.Fatal("config's column type should default to integer, but was ", c.ColumnType)
+	}
+
+	if c.Format != "unix" {
+		t.Fatal("config's format should default to unix, but was ", c.Format)
+	}
 }
 
 func TestOverlays(t *testing.T) {

--- a/pgmgr/config_test.go
+++ b/pgmgr/config_test.go
@@ -103,3 +103,24 @@ func TestURL(t *testing.T) {
 		t.Fatal("config did not populate itself from the given URL:", c)
 	}
 }
+
+func TestValidation(t *testing.T) {
+	c := &pgmgr.Config{}
+	c.Format = "wrong"
+
+	if err := pgmgr.LoadConfig(c, &TestContext{}); err == nil {
+		t.Fatal("LoadConfig should reject invalid Format value")
+	}
+
+	c.Format = ""
+	c.ColumnType = "wrong"
+	if err := pgmgr.LoadConfig(c, &TestContext{}); err == nil {
+		t.Fatal("LoadConfig should reject invalid ColumnType value")
+	}
+
+	c.Format = "datetime"
+	c.ColumnType = "integer"
+	if err := pgmgr.LoadConfig(c, &TestContext{}); err == nil {
+		t.Fatal("LoadConfig should prevent Format=datetime when ColumnType=integer")
+	}
+}

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -222,6 +222,7 @@ func CreateMigration(c *Config, name string) error {
 }
 
 func generateVersion(c *Config) string {
+	// TODO: guarantee no conflicts by incrementing if there is a conflict
 	t := time.Now()
 
 	if c.Format == "datetime" {

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -29,6 +29,8 @@ const (
 	UP
 )
 
+const datetimeFormat = "20060102130405"
+
 // Create creates the database specified by the configuration.
 func Create(c *Config) error {
 	return sh("createdb", []string{c.Database})
@@ -193,7 +195,7 @@ func Initialize(c *Config) error {
 
 // CreateMigration generates new, empty migration files.
 func CreateMigration(c *Config, name string) error {
-	version := generateVersion()
+	version := generateVersion(c)
 	upFilepath := filepath.Join(c.MigrationFolder, fmt.Sprint(version, "_", name, ".up.sql"))
 	downFilepath := filepath.Join(c.MigrationFolder, fmt.Sprint(version, "_", name, ".down.sql"))
 
@@ -212,10 +214,14 @@ func CreateMigration(c *Config, name string) error {
 	return nil
 }
 
-func generateVersion() int {
-	// TODO: guarantee no conflicts by incrementing if there is a conflict
-	v := int(time.Now().Unix())
-	return v
+func generateVersion(c *Config) string {
+	t := time.Now()
+
+	if c.Format == "datetime" {
+		return t.Format(datetimeFormat)
+	}
+
+	return strconv.FormatInt(t.Unix(), 10)
 }
 
 // need access to the original query contents in order to print it out properly,

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -242,6 +242,24 @@ func TestCreateMigration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	expectedStringVersion := time.Now().Format(datetimeFormat)
+	config := globalConfig()
+	config.Format = "datetime"
+	err = pgmgr.CreateMigration(config, "rails_style")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testSh(t, "stat", []string{fmt.Sprint("/tmp/migrations/", expectedStringVersion, "_rails_style.up.sql")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testSh(t, "stat", []string{fmt.Sprint("/tmp/migrations/", expectedStringVersion, "_rails_style.down.sql")})
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 // redundant, but I'm also lazy

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -152,6 +152,25 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestColumnTypeString(t *testing.T) {
+	testSh(t, "dropdb", []string{"testdb"})
+	testSh(t, "createdb", []string{"testdb"})
+
+	config := globalConfig()
+	config.ColumnType = "string"
+	pgmgr.Initialize(config)
+
+	testSh(t, "psql", []string{"-e", "-d", "testdb", "-c", "INSERT INTO schema_migrations (version) VALUES ('20150910120933')"})
+	version, err := pgmgr.Version(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if version != 20150910120933 {
+		t.Fatal("expected version to be 20150910120933, got", version)
+	}
+}
+
 func TestMigrate(t *testing.T) {
 	// start with an empty DB
 	testSh(t, "dropdb", []string{"testdb"})


### PR DESCRIPTION
I have a project moving from ActiveRecord to go, so it'd be nice if pgmgr could support schema migrations in the same format. Plus epoch time is annoying. =)

I haven't tested this branch out on that project yet; there's probably more to be done still. Just getting the PR in now.