### PR TITLE
Configurable schema_migrations table name and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ variable `PGMGR_CONFIG_FILE`. It should look something like:
   "username": "test",
   "password": "test",
   "database": "testdb",
+  "migration-table": "public.schema_migrations",
   "migration-folder": "db/migrate",
   "dump-file": "db/dump.sql",
   "column-type": "integer",
@@ -78,6 +79,13 @@ The `format` option can be `unix` or `datetime`. The `unix` format is
 the integer epoch time; the `datetime` uses versions similar to ActiveRecord,
 such as `20150910120933`. In order to use the `datetime` format, you must
 also use the `string` column type.
+
+The `migration-table` option can be used to specify an alternate table name
+in which to track migration status. It defaults to the schema un-qualified
+`schema_migrations`, which will typically create a table in the `public`
+schema unless the database's default search path has been modified. If you
+use a schema qualified name, pgmgr will attempt to create the schema first
+if it does not yet exist.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The values above map to these environment variables:
 * `PGMGR_DATABASE`
 * `PGMGR_DUMP_FILE` (the filepath to dump the database definition out to)
 * `PGMGR_SEED_TABLES` (tables to include data with when dumping the database)
+* `PGMGR_COLUMN_TYPE`
+* `PGMGR_FORMAT`
+* `PGMGR_MIGRATION_TABLE`
 
 If you prefer to use a connection string, you can set `PGMGR_URL` which will supersede the other configuration settings, e.g.:
 

--- a/main.go
+++ b/main.go
@@ -86,6 +86,24 @@ func main() {
 			EnvVar: "PGMGR_DUMP_FILE",
 		},
 		cli.StringFlag{
+			Name:   "column-type",
+			Value:  "integer",
+			Usage:  "column type to use in schema_migrations table; 'integer' or 'string'",
+			EnvVar: "PGMGR_COLUMN_TYPE",
+		},
+		cli.StringFlag{
+			Name:   "format",
+			Value:  "unix",
+			Usage:  "timestamp format for migrations; 'unix' or 'datetime'",
+			EnvVar: "PGMGR_FORMAT",
+		},
+		cli.StringFlag{
+			Name:   "migration-table",
+			Value:  "schema_migrations",
+			Usage:  "table to use for storing migration status; eg 'myschema.applied_migrations'",
+			EnvVar: "PGMGR_MIGRATION_TABLE",
+		},
+		cli.StringFlag{
 			Name:   "migration-folder",
 			Value:  "",
 			Usage:  "folder containing the migrations to apply",

--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -33,9 +33,10 @@ type Config struct {
 	MigrationFolder string `json:"migration-folder"`
 
 	// options
-	SeedTables []string `json:"seed-tables"`
-	ColumnType string   `json:"column-type"`
-	Format     string
+	MigrationTable string   `json:"migration-table"`
+	SeedTables     []string `json:"seed-tables"`
+	ColumnType     string   `json:"column-type"`
+	Format         string
 }
 
 // LoadConfig reads the config file, applies CLI arguments as
@@ -104,6 +105,9 @@ func (config *Config) applyDefaults() {
 	}
 	if config.ColumnType == "" {
 		config.ColumnType = "integer"
+	}
+	if config.MigrationTable == "" {
+		config.MigrationTable = "schema_migrations"
 	}
 }
 

--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
+
+	"github.com/lib/pq"
 )
 
 // Something that stores key-value pairs of various types,
@@ -170,4 +173,21 @@ func (config *Config) validate() error {
 	}
 
 	return nil
+}
+
+func (config *Config) quotedMigrationTable() string {
+	if !strings.Contains(config.MigrationTable, ".") {
+		return pq.QuoteIdentifier(config.MigrationTable)
+	}
+
+	tokens := strings.SplitN(config.MigrationTable, ".", 2)
+	return pq.QuoteIdentifier(tokens[0]) + "." + pq.QuoteIdentifier(tokens[1])
+}
+
+func (config *Config) versionColumnType() string {
+	if config.ColumnType == "string" {
+		return "CHARACTER VARYING (255)"
+	}
+
+	return "INTEGER"
 }

--- a/pgmgr/config_test.go
+++ b/pgmgr/config_test.go
@@ -3,8 +3,6 @@ package pgmgr
 import (
 	"os"
 	"testing"
-
-	"../pgmgr"
 )
 
 // create a mock to replace cli.Context
@@ -25,9 +23,9 @@ func (t *TestContext) StringSlice(key string) []string {
 }
 
 func TestDefaults(t *testing.T) {
-	c := &pgmgr.Config{}
+	c := &Config{}
 
-	pgmgr.LoadConfig(c, &TestContext{})
+	LoadConfig(c, &TestContext{})
 
 	if c.Port != 5432 {
 		t.Fatal("config's port should default to 5432")
@@ -47,7 +45,7 @@ func TestDefaults(t *testing.T) {
 }
 
 func TestOverlays(t *testing.T) {
-	c := &pgmgr.Config{}
+	c := &Config{}
 	ctx := &TestContext{IntVals: make(map[string]int)}
 
 	// should prefer the value from ctx, since
@@ -56,14 +54,14 @@ func TestOverlays(t *testing.T) {
 	ctx.IntVals["port"] = 456
 	os.Setenv("PGPORT", "789")
 
-	pgmgr.LoadConfig(c, ctx)
+	LoadConfig(c, ctx)
 
 	if c.Port != 456 {
 		t.Fatal("config's port should come from the context, but was", c.Port)
 	}
 
 	// reset
-	c = &pgmgr.Config{}
+	c = &Config{}
 	ctx = &TestContext{IntVals: make(map[string]int)}
 
 	// should prefer the value from PGPORT, since
@@ -71,14 +69,14 @@ func TestOverlays(t *testing.T) {
 	c.Port = 123
 	os.Setenv("PGPORT", "789")
 
-	pgmgr.LoadConfig(c, ctx)
+	LoadConfig(c, ctx)
 
 	if c.Port != 789 {
 		t.Fatal("config's port should come from PGPORT, but was", c.Port)
 	}
 
 	// reset
-	c = &pgmgr.Config{}
+	c = &Config{}
 	ctx = &TestContext{IntVals: make(map[string]int)}
 
 	// should prefer the value in the struct, since
@@ -86,7 +84,7 @@ func TestOverlays(t *testing.T) {
 	c.Port = 123
 	os.Setenv("PGPORT", "")
 
-	pgmgr.LoadConfig(c, ctx)
+	LoadConfig(c, ctx)
 
 	if c.Port != 123 {
 		t.Fatal("config's port should not change, but was", c.Port)
@@ -94,10 +92,10 @@ func TestOverlays(t *testing.T) {
 }
 
 func TestURL(t *testing.T) {
-	c := &pgmgr.Config{}
+	c := &Config{}
 	c.URL = "postgres://foo@bar:5431/testdb"
 
-	pgmgr.LoadConfig(c, &TestContext{})
+	LoadConfig(c, &TestContext{})
 
 	if c.Username != "foo" || c.Host != "bar" || c.Port != 5431 || c.Database != "testdb" {
 		t.Fatal("config did not populate itself from the given URL:", c)
@@ -105,22 +103,22 @@ func TestURL(t *testing.T) {
 }
 
 func TestValidation(t *testing.T) {
-	c := &pgmgr.Config{}
+	c := &Config{}
 	c.Format = "wrong"
 
-	if err := pgmgr.LoadConfig(c, &TestContext{}); err == nil {
+	if err := LoadConfig(c, &TestContext{}); err == nil {
 		t.Fatal("LoadConfig should reject invalid Format value")
 	}
 
 	c.Format = ""
 	c.ColumnType = "wrong"
-	if err := pgmgr.LoadConfig(c, &TestContext{}); err == nil {
+	if err := LoadConfig(c, &TestContext{}); err == nil {
 		t.Fatal("LoadConfig should reject invalid ColumnType value")
 	}
 
 	c.Format = "datetime"
 	c.ColumnType = "integer"
-	if err := pgmgr.LoadConfig(c, &TestContext{}); err == nil {
+	if err := LoadConfig(c, &TestContext{}); err == nil {
 		t.Fatal("LoadConfig should prevent Format=datetime when ColumnType=integer")
 	}
 }

--- a/pgmgr/config_test.go
+++ b/pgmgr/config_test.go
@@ -35,6 +35,10 @@ func TestDefaults(t *testing.T) {
 		t.Fatal("config's host should default to localhost, but was ", c.Host)
 	}
 
+	if c.MigrationTable != "schema_migrations" {
+		t.Fatal("config's migration table should default to schema_migrations, but was ", c.MigrationTable)
+	}
+
 	if c.ColumnType != "integer" {
 		t.Fatal("config's column type should default to integer, but was ", c.ColumnType)
 	}

--- a/pgmgr/config_test.go
+++ b/pgmgr/config_test.go
@@ -126,3 +126,15 @@ func TestValidation(t *testing.T) {
 		t.Fatal("LoadConfig should prevent Format=datetime when ColumnType=integer")
 	}
 }
+
+func TestQuotedMigrationTable(t *testing.T) {
+	c := &Config{MigrationTable: "abc"}
+	if c.quotedMigrationTable() != `"abc"` {
+		t.Fatal(`Migration table should be "abc", got`, c.quotedMigrationTable())
+	}
+
+	c.MigrationTable = "abc.def"
+	if c.quotedMigrationTable() != `"abc"."def"` {
+		t.Fatal(`Schema-qualified migration table should be "abc"."def", got`, c.quotedMigrationTable())
+	}
+}

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -159,7 +159,7 @@ func TestInitialize(t *testing.T) {
 
 	psqlMustExec(t, `SELECT * FROM pgmgr.applied_migrations`)
 
-	// If we specify a schema-qualified, and the schema already existed,
+	// If we specify a schema-qualified table, and the schema already existed,
 	// that's fine too.
 	resetDB(t)
 	psqlMustExec(t, `CREATE SCHEMA pgmgr;`)

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -369,13 +369,8 @@ func createDB(t *testing.T) error {
 }
 
 func clearMigrationFolder(t *testing.T) {
-	if err := testSh(t, "rm", []string{"-r", migrationFolder}); err != nil {
-		t.Fatalf("Could not remove directory %s: %s", migrationFolder, err)
-	}
-
-	if err := testSh(t, "mkdir", []string{migrationFolder}); err != nil {
-		t.Fatalf("Could not create directory %s: %s", migrationFolder, err)
-	}
+	testSh(t, "rm", []string{"-r", migrationFolder})
+	testSh(t, "mkdir", []string{migrationFolder})
 }
 
 func writeMigration(t *testing.T, name, contents string) {

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -28,9 +28,7 @@ func globalConfig() *Config {
 }
 
 func TestCreate(t *testing.T) {
-	if err := dropDB(t); err != nil {
-		t.Fatal("dropdb failed: ", err)
-	}
+	dropDB(t)
 
 	if err := Create(globalConfig()); err != nil {
 		t.Log(err)

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -133,7 +133,7 @@ func TestInitialize(t *testing.T) {
 	// Default config should create public.schema_migrations
 	resetDB(t)
 
-	if err := pgmgr.Initialize(config); err != nil {
+	if err := Initialize(config); err != nil {
 		t.Fatal("Initialize failed: ", err)
 	}
 
@@ -143,7 +143,7 @@ func TestInitialize(t *testing.T) {
 	resetDB(t)
 	config.MigrationTable = "applied_migrations"
 
-	if err := pgmgr.Initialize(config); err != nil {
+	if err := Initialize(config); err != nil {
 		t.Fatal("Initialize failed: ", err)
 	}
 
@@ -153,7 +153,7 @@ func TestInitialize(t *testing.T) {
 	// created if it does not yet exist.
 	resetDB(t)
 	config.MigrationTable = "pgmgr.applied_migrations"
-	if err := pgmgr.Initialize(config); err != nil {
+	if err := Initialize(config); err != nil {
 		t.Fatal("Initialize failed: ", err)
 	}
 
@@ -163,7 +163,7 @@ func TestInitialize(t *testing.T) {
 	// that's fine too.
 	resetDB(t)
 	psqlMustExec(t, `CREATE SCHEMA pgmgr;`)
-	if err := pgmgr.Initialize(config); err != nil {
+	if err := Initialize(config); err != nil {
 		t.Fatal("Initialize failed: ", err)
 	}
 
@@ -212,7 +212,6 @@ func TestColumnTypeString(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	// start with an empty DB
 	resetDB(t)
 	clearMigrationFolder(t)
 
@@ -269,7 +268,6 @@ func TestMigrate(t *testing.T) {
 }
 
 func TestMigrateColumnTypeString(t *testing.T) {
-	// start with an empty DB
 	resetDB(t)
 	clearMigrationFolder(t)
 
@@ -315,7 +313,6 @@ func TestMigrateColumnTypeString(t *testing.T) {
 }
 
 func TestMigrateNoTransaction(t *testing.T) {
-	// start with an empty DB
 	resetDB(t)
 	clearMigrationFolder(t)
 
@@ -327,6 +324,27 @@ func TestMigrateNoTransaction(t *testing.T) {
 	err := Migrate(globalConfig())
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestMigrateCustomMigrationTable(t *testing.T) {
+	resetDB(t)
+	clearMigrationFolder(t)
+	writeMigration(t, "001_create_foos.up.sql", `CREATE TABLE foos (foo_id INTEGER);`)
+
+	config := globalConfig()
+	config.MigrationTable = "pgmgr.migrations"
+	if err := Migrate(config); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := Version(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v != 1 {
+		t.Fatal("Expected version 1, got ", v)
 	}
 }
 


### PR DESCRIPTION
This currently includes all of #12; I'll rebase after I get that PR working reasonably.

I don't want `schema_migrations` in my public schema. This exposes Yet Another Config Option :tm: to control the table name, optionally schema qualified. If the schema does not exist, pgmgr will create it, and then create the table inside of it.