### PR TITLE
Ensure Initialize can run multiple times

### DIFF
--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -134,7 +134,11 @@ func TestInitialize(t *testing.T) {
 	resetDB(t)
 
 	if err := Initialize(config); err != nil {
-		t.Fatal("Initialize failed: ", err)
+		t.Fatal("Initialize failed:", err)
+	}
+
+	if err := Initialize(config); err != nil {
+		t.Fatal("Initialize was not safe to run twice:", err)
 	}
 
 	psqlMustExec(t, `SELECT * FROM public.schema_migrations;`)


### PR DESCRIPTION
My previous change in #13 introduced the bug that, if the
schema_migrations table exists but was empty, the Initialize function
would be called and then fail attempting to create the table.

Instead, I've pulled the check for the table's existence into Initialize
itself, so that it can simply opt-out of creating it.