### PR TITLE
Make the filename regular expression stricter

### DIFF
--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -447,7 +447,7 @@ func migrations(c *Config, direction string) ([]Migration, error) {
 	}
 
 	for _, file := range files {
-		if match, _ := regexp.MatchString("[0-9]+_.+\\."+direction+"\\.sql", file.Name()); match {
+		if match, _ := regexp.MatchString("^[0-9]+_.+\\."+direction+"\\.sql$", file.Name()); match {
 			version, _ := strconv.ParseInt(re.FindString(file.Name()), 10, 64)
 			migrations = append(migrations, Migration{Filename: file.Name(), Version: version})
 		}

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -266,7 +266,7 @@ func TestMigrate(t *testing.T) {
 	err = Migrate(globalConfig())
 	if err != nil {
 		t.Log(err)
-		t.Fatal("Could not apply third migration!")
+		t.Fatal("Migration returned an error instead of being skipped!")
 	}
 
 	psqlMustNotExec(t, `SELECT * FROM baz;`)


### PR DESCRIPTION
I had an issue with running migrations while one of the migration files is being edited by vim. It creates a .swp file which ends up being recognized as a migration. As a result, I made the filename regular expression stricter.