### PR TITLE
Print out error message on failed rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ pgmgr migration MigrationName   # generates files for a new migration
 pgmgr db create                 # creates the database if it doesn't exist
 pgmgr db drop                   # drop the database
 pgmgr db migrate                # apply un-applied migrations
+pgmgr db rollback               # reverts the latest migration, if possible.
 pgmgr db load                   # loads the schema dump file from PGMGR_DUMP_FILE
 pgmgr db dump                   # dumps the database structure & seeds to PGMGR_DUMP_FILE
 ```

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -107,9 +107,7 @@ func Migrate(c *Config) error {
 			t0 := time.Now()
 
 			if err = applyMigration(c, m, UP); err != nil { // halt the migration process and return the error.
-				fmt.Println(err)
-				fmt.Println("")
-				fmt.Println("ERROR! Aborting the migration process.")
+				printFailedMigrationMessage(err)
 				return err
 			}
 
@@ -150,6 +148,7 @@ func Rollback(c *Config) error {
 	t0 := time.Now()
 
 	if err = applyMigration(c, *toRollback, DOWN); err != nil {
+		printFailedMigrationMessage(err)
 		return err
 	}
 
@@ -471,4 +470,10 @@ func shRead(command string, args []string) (*[]byte, error) {
 	c := exec.Command(command, args...)
 	output, err := c.CombinedOutput()
 	return &output, err
+}
+
+func printFailedMigrationMessage(err error) {
+	fmt.Fprintf(os.Stderr, err.Error())
+	fmt.Fprintf(os.Stderr, "\n\n")
+	fmt.Fprintf(os.Stderr, "ERROR! Aborting the migration process.")
 }

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -25,6 +25,11 @@ const (
 
 const datetimeFormat = "20060102130405"
 
+const (
+	MIGRATION = "migration"
+	ROLLBACK  = "rollback"
+)
+
 // Migration stores a single migration's version and filename.
 type Migration struct {
 	Filename string
@@ -107,7 +112,7 @@ func Migrate(c *Config) error {
 			t0 := time.Now()
 
 			if err = applyMigration(c, m, UP); err != nil { // halt the migration process and return the error.
-				printFailedMigrationMessage(err)
+				printFailedMigrationMessage(err, MIGRATION)
 				return err
 			}
 
@@ -148,7 +153,7 @@ func Rollback(c *Config) error {
 	t0 := time.Now()
 
 	if err = applyMigration(c, *toRollback, DOWN); err != nil {
-		printFailedMigrationMessage(err)
+		printFailedMigrationMessage(err, ROLLBACK)
 		return err
 	}
 
@@ -472,8 +477,8 @@ func shRead(command string, args []string) (*[]byte, error) {
 	return &output, err
 }
 
-func printFailedMigrationMessage(err error) {
+func printFailedMigrationMessage(err error, migration_type string) {
 	fmt.Fprintf(os.Stderr, err.Error())
 	fmt.Fprintf(os.Stderr, "\n\n")
-	fmt.Fprintf(os.Stderr, "ERROR! Aborting the migration process.")
+	fmt.Fprintf(os.Stderr, "ERROR! Aborting the "+migration_type+" process.")
 }

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -25,6 +25,7 @@ const (
 
 const datetimeFormat = "20060102130405"
 
+// Migration directions used for error message building
 const (
 	MIGRATION = "migration"
 	ROLLBACK  = "rollback"
@@ -477,8 +478,8 @@ func shRead(command string, args []string) (*[]byte, error) {
 	return &output, err
 }
 
-func printFailedMigrationMessage(err error, migration_type string) {
+func printFailedMigrationMessage(err error, migrationType string) {
 	fmt.Fprintf(os.Stderr, err.Error())
 	fmt.Fprintf(os.Stderr, "\n\n")
-	fmt.Fprintf(os.Stderr, "ERROR! Aborting the "+migration_type+" process.")
+	fmt.Fprintf(os.Stderr, "ERROR! Aborting the "+migrationType+" process.")
 }

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -409,13 +409,12 @@ func TestRollback(t *testing.T) {
 	resetDB(t)
 	clearMigrationFolder(t)
 
-	// add our first migration
-	writeMigration(t, "001_this_is_a_migration.up.sql", `
+	writeMigration(t, "001_a_migration.up.sql", `
 		CREATE TABLE foos (foo_id INTEGER);
 		INSERT INTO foos (foo_id) VALUES (1), (2), (3);
 	`)
 
-	writeMigration(t, "001_this_is_a_migration.down.sql", `DROP TABLE foos;`)
+	writeMigration(t, "001_a_migration.down.sql", `DROP TABLE foos;`)
 
 	err := Migrate(globalConfig())
 	if err != nil {
@@ -436,15 +435,21 @@ func TestRollbackFailed(t *testing.T) {
 	resetDB(t)
 	clearMigrationFolder(t)
 
-	// add our first migration
-	writeMigration(t, "001_this_is_a_migration.up.sql", `
+	writeMigration(t, "001_a_migration.up.sql", `
 		CREATE TABLE foos (foo_id INTEGER);
 		INSERT INTO foos (foo_id) VALUES (1), (2), (3);
 	`)
 
-	writeMigration(t, "001_this_is_a_migration.down.sql", `DROP TABLE foos;`)
+	// Note the syntax error in the SQL
+	writeMigration(t, "001_a_migration.down.sql", `DRO TABLE foos;`)
 
-	err := Rollback(globalConfig())
+	err := Migrate(globalConfig())
+	if err != nil {
+		t.Log(err)
+		t.Fatal("Migrations failed to run.")
+	}
+
+	err = Rollback(globalConfig())
 	if err == nil {
 		t.Fatal("Rollback succeeded when it shouldn't have.")
 	}

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -405,6 +405,51 @@ func TestCreateMigration(t *testing.T) {
 	assertFileExists(fmt.Sprint(expectedStringVersion, "_create_index.no_txn.down.sql"))
 }
 
+func TestRollback(t *testing.T) {
+	resetDB(t)
+	clearMigrationFolder(t)
+
+	// add our first migration
+	writeMigration(t, "001_this_is_a_migration.up.sql", `
+		CREATE TABLE foos (foo_id INTEGER);
+		INSERT INTO foos (foo_id) VALUES (1), (2), (3);
+	`)
+
+	writeMigration(t, "001_this_is_a_migration.down.sql", `DROP TABLE foos;`)
+
+	err := Migrate(globalConfig())
+	if err != nil {
+		t.Log(err)
+		t.Fatal("Migrations failed to run.")
+	}
+
+	err = Rollback(globalConfig())
+	if err != nil {
+		t.Log(err)
+		t.Fatal("Failed to rollback.")
+	}
+
+	psqlMustNotExec(t, "SELECT * FROM bars;")
+}
+
+func TestRollbackFailed(t *testing.T) {
+	resetDB(t)
+	clearMigrationFolder(t)
+
+	// add our first migration
+	writeMigration(t, "001_this_is_a_migration.up.sql", `
+		CREATE TABLE foos (foo_id INTEGER);
+		INSERT INTO foos (foo_id) VALUES (1), (2), (3);
+	`)
+
+	writeMigration(t, "001_this_is_a_migration.down.sql", `DROP TABLE foos;`)
+
+	err := Rollback(globalConfig())
+	if err == nil {
+		t.Fatal("Rollback succeeded when it shouldn't have.")
+	}
+}
+
 // redundant, but I'm also lazy
 func testSh(t *testing.T, command string, args []string) error {
 	c := exec.Command(command, args...)


### PR DESCRIPTION
* Add tests for the `Rollback()` function
* Print out the error message on a failed `Rollback()`. I had an issue where it only said applying the `down` migration without telling me if it finished or not. To debug I always had to run the .sql file via `psql`.
* Added the `rollback` explanation to the README

One more thing to consider is that I changed the failure errors in `Migrate` to print to stderr instead of stdout. I hope this won't cause any issues. If it is an issue, I can change the `fmt.Fprintf`'s to print to stdout.