### PR TITLE
Add a missing newline in the error message

### DIFF
--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -481,5 +481,5 @@ func shRead(command string, args []string) (*[]byte, error) {
 func printFailedMigrationMessage(err error, migrationType string) {
 	fmt.Fprintf(os.Stderr, err.Error())
 	fmt.Fprintf(os.Stderr, "\n\n")
-	fmt.Fprintf(os.Stderr, "ERROR! Aborting the "+migrationType+" process.")
+	fmt.Fprintf(os.Stderr, "ERROR! Aborting the "+migrationType+" process.\n")
 }


### PR DESCRIPTION
Apparently there is a missing newline since I changed it to use `fmt.Fprintf`. It kind of messes up the formatting.