### PR TITLE
Only run golint for Go 1.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - tip
 
 script:
-  - go get -u github.com/golang/lint/golint
+  - '[[ $(go version) =~ "1.4" ]] || go get -u github.com/golang/lint/golint'
   - test -z "$(gofmt -l .)"
-  - test -z "$(golint ./...)"
+  - '[[ $(go version) =~ "1.4" ]] || test -z "$(golint ./...)"'
   - go test -v ./...


### PR DESCRIPTION
This appears to have been added recently as a restriction for golint, which is why previous builds worked.  Eventually we'll probably be able to just not run CI on 1.4, but for now we'll just exclude golint for those builds.