### PR TITLE
Add support for Postgres' sslmode connection parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ variable `PGMGR_CONFIG_FILE`. It should look something like:
   "username": "test",
   "password": "test",
   "database": "testdb",
+  "sslmode": "disable",
   "migration-table": "public.schema_migrations",
   "migration-folder": "db/migrate",
   "dump-file": "db/dump.sql",
@@ -96,6 +97,7 @@ The values above map to these environment variables:
 * `PGMGR_USERNAME`
 * `PGMGR_PASSWORD`
 * `PGMGR_DATABASE`
+* `PGMGR_SSLMODE`
 * `PGMGR_DUMP_FILE` (the filepath to dump the database definition out to)
 * `PGMGR_SEED_TABLES` (tables to include data with when dumping the database)
 * `PGMGR_COLUMN_TYPE`
@@ -105,7 +107,7 @@ The values above map to these environment variables:
 If you prefer to use a connection string, you can set `PGMGR_URL` which will supersede the other configuration settings, e.g.:
 
 ```
-PGMGR_URL='postgres://test@localhost/testdb?sslmode=false&password=test'
+PGMGR_URL='postgres://test:test@localhost/testdb?sslmode=require'
 ```
 
 Also, for host, port, username, password, and database, if you haven't set a

--- a/main.go
+++ b/main.go
@@ -74,6 +74,12 @@ func main() {
 			EnvVar: "PGMGR_PORT",
 		},
 		cli.StringFlag{
+			Name:   "sslmode",
+			Value:  "",
+			Usage:  "whether to verify SSL connection or not. See https://www.postgresql.org/docs/9.1/static/libpq-ssl.html",
+			EnvVar: "PGMGR_SSLMODE",
+		},
+		cli.StringFlag{
 			Name:   "url",
 			Value:  "",
 			Usage:  "connection URL or DSN containing connection info; will override the other params if given",

--- a/pgmgr/config_test.go
+++ b/pgmgr/config_test.go
@@ -46,6 +46,10 @@ func TestDefaults(t *testing.T) {
 	if c.Format != "unix" {
 		t.Fatal("config's format should default to unix, but was ", c.Format)
 	}
+
+	if c.SslMode != "disable" {
+		t.Fatal("config's sslmode should default to 'disable', but was ", c.SslMode)
+	}
 }
 
 func TestOverlays(t *testing.T) {
@@ -97,11 +101,11 @@ func TestOverlays(t *testing.T) {
 
 func TestURL(t *testing.T) {
 	c := &Config{}
-	c.URL = "postgres://foo@bar:5431/testdb"
+	c.URL = "postgres://foo@bar:5431/testdb?sslmode=verify-ca"
 
 	LoadConfig(c, &TestContext{})
 
-	if c.Username != "foo" || c.Host != "bar" || c.Port != 5431 || c.Database != "testdb" {
+	if c.Username != "foo" || c.Host != "bar" || c.Port != 5431 || c.Database != "testdb" || c.SslMode != "verify-ca" {
 		t.Fatal("config did not populate itself from the given URL:", c)
 	}
 }

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -439,7 +439,7 @@ func sqlConnectionString(c *Config) string {
 		" password='", c.Password, "'",
 		" host='", c.Host, "'",
 		" port=", c.Port,
-		" sslmode=", "disable")
+		" sslmode=", c.SslMode)
 }
 
 func migrations(c *Config, direction string) ([]Migration, error) {

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -25,6 +25,7 @@ func globalConfig() *Config {
 		DumpFile:        dumpFile,
 		MigrationFolder: migrationFolder,
 		MigrationTable:  "schema_migrations",
+		SslMode:         "disable",
 	}
 }
 


### PR DESCRIPTION
For supported values of this parameter and their meanings, see [the docs](https://www.postgresql.org/docs/9.1/static/libpq-ssl.html). Can be configured in pgmgr by either the `--sslmode` CLI flag, the `"sslmode"` attribute in `.pgmgr.json`, the `PGMGR_SSLMODE` env var, or the default `PGSSLMODE` envvar.

Closes #26.