### PR TITLE
Loosen URL-matching regex to handle all database names.

### DIFF
--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -157,7 +157,7 @@ func (config *Config) applyArguments(ctx argumentContext) {
 func (config *Config) overrideFromURL() {
 	// parse the DSN and populate the other configuration values. Some of the pg commands
 	// accept a DSN parameter, but not all, so this will help unify things.
-	r := regexp.MustCompile("^postgres://(.*)@(.*):([0-9]+)/([a-zA-Z0-9_-]+)")
+	r := regexp.MustCompile("^postgres://(.*)@(.*):([0-9]+)/([^?]+)")
 	m := r.FindStringSubmatch(config.URL)
 	if len(m) > 0 {
 		config.Username = m[1]

--- a/pgmgr/config_test.go
+++ b/pgmgr/config_test.go
@@ -101,11 +101,11 @@ func TestOverlays(t *testing.T) {
 
 func TestURL(t *testing.T) {
 	c := &Config{}
-	c.URL = "postgres://foo@bar:5431/testdb?sslmode=verify-ca"
+	c.URL = "postgres://foo@bar:5431/test-db.one?sslmode=verify-ca"
 
 	LoadConfig(c, &TestContext{})
 
-	if c.Username != "foo" || c.Host != "bar" || c.Port != 5431 || c.Database != "testdb" || c.SslMode != "verify-ca" {
+	if c.Username != "foo" || c.Host != "bar" || c.Port != 5431 || c.Database != "test-db.one" || c.SslMode != "verify-ca" {
 		t.Fatal("config did not populate itself from the given URL:", c)
 	}
 }


### PR DESCRIPTION
As described in https://github.com/go-bootstrap/go-bootstrap/issues/47, a database name of `test.db` (which contains a period) when supplied in a connection URL (`PGMGR_URL=postgresql://localhost:5432/test.db`) is not parsed correctly. This PR fixes the issue by  changing the regex to just match anything that's not the query separator (`?`).