### PR TITLE
Test on Go v1.6 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.4
   - 1.5
+  - 1.6
   - tip
 
 script:


### PR DESCRIPTION
Now that Go has released 1.7, I want to make sure pgmgr maintains compatibility with 1.6. Possibly we could remove 1.4, but it's not that old and I can't find a good source on version usage.