### PR TITLE
[fix] Build the connection string with only known values

### DIFF
--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -433,13 +433,22 @@ func openConnection(c *Config) (*sql.DB, error) {
 }
 
 func sqlConnectionString(c *Config) string {
-	return fmt.Sprint(
-		" user='", c.Username, "'",
-		" dbname='", c.Database, "'",
-		" password='", c.Password, "'",
+	args := make([]interface{}, 0)
+
+	if c.Database != "" {
+		args = append(args, " dbname='", c.Database, "'")
+	}
+
+	if c.Password != "" {
+		args = append(args, " password='", c.Password, "'")
+	}
+
+	args = append(args,
 		" host='", c.Host, "'",
 		" port=", c.Port,
 		" sslmode=", c.SslMode)
+
+	return fmt.Sprint(args...)
 }
 
 func migrations(c *Config, direction string) ([]Migration, error) {


### PR DESCRIPTION
Not entirely sure what exposed this behavior -- possibly a Travis change, or a Postgres version change, or a pq change -- but the change here makes sense regardless. `dbname` should likely always be present, but we'll leave it up to the adapter to decide that.