### PR TITLE
PSQL migration driver & create/drop/dump fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: go
 
 go:
-  - 1.4
-  - 1.5
-  - 1.6
-  - 1.7
-  - tip
+  - '1.10'
+  - '1.11'
+  - stable
+  - master
+
+addons:
+  postgresql: "10"
+
+matrix:
+  allow_failures:
+    - go: master
 
 script:
-  - '[[ $(go version) =~ 1.[45] ]] || go get -u github.com/golang/lint/golint'
+  - go get -u golang.org/x/lint/golint
+  - test -z "$(golint ./...)"
   - test -z "$(gofmt -l .)"
-  - '[[ $(go version) =~ 1.[45] ]] || test -z "$(golint ./...)"'
   - createuser pgmgr -s
   - go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ script:
   - '[[ $(go version) =~ 1.[45] ]] || go get -u github.com/golang/lint/golint'
   - test -z "$(gofmt -l .)"
   - '[[ $(go version) =~ 1.[45] ]] || test -z "$(golint ./...)"'
+  - createuser pgmgr -s
   - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ schema unless the database's default search path has been modified. If you
 use a schema qualified name, pgmgr will attempt to create the schema first
 if it does not yet exist.
 
+`migration-driver`, added in August 2019, allows migrations to be run either
+through the Go `pq` library (which runs the migrations as a single multi-statement
+command) or through the `psql` command-line utility. The possible options are
+`'pq'` or `'psql'`. The default is currently `pq` (subject to change).
+
 ### Environment variables
 
 The values above map to these environment variables:
@@ -103,6 +108,7 @@ The values above map to these environment variables:
 * `PGMGR_COLUMN_TYPE`
 * `PGMGR_FORMAT`
 * `PGMGR_MIGRATION_TABLE`
+* `PGMGR_MIGRATION_DRIVER`
 
 If you prefer to use a connection string, you can set `PGMGR_URL` which will supersede the other configuration settings, e.g.:
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 # TODO
 
 * Add status command to view status of all migrations in MigrationFolder
-* Support sslmode=require
 * Support PGPASSFILE

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
 # TODO
 
-* Add status command to view status of all migrations in MigrationFolder
+* Add `status` command to view status of all migrations in MigrationFolder
 * Support PGPASSFILE

--- a/main.go
+++ b/main.go
@@ -115,6 +115,12 @@ func main() {
 			Usage:  "folder containing the migrations to apply",
 			EnvVar: "PGMGR_MIGRATION_FOLDER",
 		},
+		cli.StringFlag{
+			Name:   "migration-driver",
+			Value:  "",
+			Usage:  "how to apply the migrations. supported options are pq (which will execute the migration as one statement) or psql (which will use the psql binary on your system to execute each line)",
+			EnvVar: "PGMGR_MIGRATION_DRIVER",
+		},
 		cli.StringSliceFlag{
 			Name:   "seed-tables",
 			Value:  (*cli.StringSlice)(&s),

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/rnubel/pgmgr/pgmgr"
-	"github.com/urfave/cli"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 func displayErrorOrMessage(err error, args ...interface{}) error {


### PR DESCRIPTION
1) This introduces a new MigrationDriver config variable, which can be either "pq" (the current method) or "psql" (a new method that invokes psql directly). For now that variable will remain defaulted to "pq" until we've proven out the psql driver at Enova.

The main benefit of the psql driver is that your migrations are executed one statement at a time, rather than as a multi-command statement. This enables things like multiple concurrent index creation and works better with logical replication.

2) Certain commands like "db create" and "db dump" did not use the configured connection variables, instead using whatever your environment's PG vars were set to. This wasn't a huge deal as those commands weren't used in prod, but it still was a frequent cause of confusion. The fix was to dump pgmgr's configuration into the ENV before running these commands.

Addresses #38.

cc: @jfinzel