### PR TITLE
Drop go 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - '1.10'
   - '1.11'
+  - '1.12'
   - stable
   - master
 


### PR DESCRIPTION
pgmgr's dependencies don't resolve for go 1.10 currently; since that's now several versions behind I'm going to drop it off of the travis builds.