### PR TITLE
Psql Migrations: follow-up

### DIFF
--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -323,7 +323,7 @@ func applyMigrationByPsql(c *Config, m Migration, direction int) error {
 	}
 
 	tmpfile.WriteString(
-		fmt.Sprintf(`INSERT INTO %s (version) VALUES ('%d');`, c.quotedMigrationTable(), m.Version),
+		fmt.Sprintf(`; INSERT INTO %s (version) VALUES ('%d');`, c.quotedMigrationTable(), m.Version),
 	)
 
 	if err := tmpfile.Close(); err != nil {

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -494,11 +494,12 @@ func migrationIsApplied(c *Config, version int64) (bool, error) {
 }
 
 func openConnection(c *Config) (*sql.DB, error) {
-	db, err := sql.Open("postgres", sqlConnectionString(c))
+	db, err := sql.Open("postgres", SQLConnectionString(c))
 	return db, err
 }
 
-func sqlConnectionString(c *Config) string {
+// SQLConnectionString formats the values pulled from the config into a connection string
+func SQLConnectionString(c *Config) string {
 	args := make([]interface{}, 0)
 
 	if c.Username != "" {

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -397,6 +397,29 @@ func TestMigratePsqlDriver(t *testing.T) {
 	}
 }
 
+func TestMigratePsqlAddsSemicolon(t *testing.T) {
+	resetDB(t)
+	clearMigrationFolder(t)
+
+	writeMigration(t, "001_create_foos.up.sql", `CREATE TABLE foos (foo_id INTEGER, val BOOLEAN)`)
+
+	config := globalConfig()
+	config.MigrationDriver = "psql"
+
+	if err := Migrate(config); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := Version(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v != 1 {
+		t.Fatal("Expected migration to apply; did not -- version is still: ", v)
+	}
+}
+
 func TestMigratePsqlFailedMigration(t *testing.T) {
 	resetDB(t)
 	clearMigrationFolder(t)


### PR DESCRIPTION
1. Migrations may not always have semicolons at the end -- that's OK per normal psql behavior, so we should allow it for the psql driver. We accomplish this just by pre-pending a semicolon to the version increment statement, which is always safe to do.

2. Some users have duped the SQLConnectionString logic into their own apps, when trying to share pgmgr's config values for their own db connections, so we now export that function.