### PR TITLE
Drop gopkg.in for module compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - '1.11'
   - '1.12'
   - stable
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ go:
   - stable
   - master
 
+env:
+  - GO111MODULE=1
+
 addons:
   postgresql: "10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ go:
   - master
 
 env:
-  - GO111MODULE=1
+  global:
+    - GO111MODULE=on
 
 addons:
   postgresql: "10"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rnubel/pgmgr
 
-go 1.12
+go 1.11
 
 require (
 	github.com/lib/pq v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rnubel/pgmgr
 
-go 1.11
+go 1.12
 
 require (
 	github.com/lib/pq v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/rnubel/pgmgr
+
+go 1.12
+
+require (
+	github.com/lib/pq v1.2.0
+	github.com/urfave/cli v1.22.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
+github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/rnubel/pgmgr/pgmgr"
-	cli "gopkg.in/urfave/cli.v1"
+	cli "github.com/urfave/cli"
 )
 
 func displayErrorOrMessage(err error, args ...interface{}) error {


### PR DESCRIPTION
The CLI package has stabilized its master branch to be locked at v1, so the gopkg.in hack is no longer needed (and was breaking module resolution when trying to install pgmgr).