### PR TITLE
Change compress to no-compress & update how gz file is read

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,10 +121,10 @@ func main() {
 			Usage:  "how to apply the migrations. supported options are pq (which will execute the migration as one statement) or psql (which will use the psql binary on your system to execute each line)",
 			EnvVar: "PGMGR_MIGRATION_DRIVER",
 		},
-		cli.BoolTFlag{
-			Name:   "compress",
-			Usage:  "whether to compress the database dump (t/f). If t compression is set to 9. See pg_dump -Z.",
-			EnvVar: "PGMGR_COMPRESS",
+		cli.BoolFlag{
+			Name:   "no-compress",
+			Usage:  "whether to skip compressing the database dump. See pg_dump -Z.",
+			EnvVar: "PGMGR_NO_COMPRESS",
 		},
 		cli.BoolFlag{
 			Name:   "include-triggers",

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	app.Name = "pgmgr"
 	app.Usage = "manage your app's Postgres database"
-	app.Version = "1.1.0"
+	app.Version = "1.1.1"
 
 	var s []string
 

--- a/pgmgr/dump_config_test.go
+++ b/pgmgr/dump_config_test.go
@@ -9,7 +9,6 @@ func TestDumpFlags(test *testing.T) {
 	c := DumpConfig{
 		IncludeTables:  []string{"iTable1", "iTable2"},
 		ExcludeSchemas: []string{},
-		Compress:       true,
 	}
 
 	flags := strings.Join(c.baseFlags(), " ")
@@ -25,7 +24,7 @@ func TestDumpFlags(test *testing.T) {
 		test.Fatal("Dump flags should set -x when IncludePrivileges is 'f'")
 	}
 
-	c.Compress = false
+	c.NoCompress = true
 	c.IncludePrivileges = true
 	flags = strings.Join(c.baseFlags(), " ")
 	if strings.Contains(flags, "-Z 9") {
@@ -69,8 +68,8 @@ func TestDumpDefaults(t *testing.T) {
 		t.Fatal("dump config's dump-file should default to 'dump.sql', but was ", c.DumpConfig.DumpFile)
 	}
 
-	if !c.DumpConfig.Compress {
-		t.Fatal("dump config's compression should default to 't', but was ", c.DumpConfig.Compress)
+	if c.DumpConfig.NoCompress {
+		t.Fatal("dump config's compression should default to 't', but was ", c.DumpConfig.NoCompress)
 	}
 
 	if c.DumpConfig.IncludePrivileges {
@@ -91,8 +90,8 @@ func TestDumpDefaults(t *testing.T) {
 	if c.DumpConfig.DumpFile != "dump.file.sql" {
 		t.Fatal("dump config should strip '.gz' suffix, but was ", c.DumpConfig.DumpFile)
 	}
-	if !c.DumpConfig.Compress {
-		t.Fatal("dump config should set Compress='t' if '.gz' suffix is present, but was ", c.DumpConfig.Compress)
+	if c.DumpConfig.NoCompress {
+		t.Fatal("dump config should set Compress='t' if '.gz' suffix is present, but was ", c.DumpConfig.NoCompress)
 	}
 }
 

--- a/pgmgr/dump_config_test.go
+++ b/pgmgr/dump_config_test.go
@@ -18,7 +18,7 @@ func TestDumpFlags(test *testing.T) {
 		}
 	}
 	if !strings.Contains(flags, "-Z 9") {
-		test.Fatal("Dump flags should set compression level to 9 when compressed is 't'")
+		test.Fatal("Dump flags should set compression level to 9 when NoCompress is 'f'")
 	}
 	if !strings.Contains(flags, "-x") {
 		test.Fatal("Dump flags should set -x when IncludePrivileges is 'f'")
@@ -28,7 +28,7 @@ func TestDumpFlags(test *testing.T) {
 	c.IncludePrivileges = true
 	flags = strings.Join(c.baseFlags(), " ")
 	if strings.Contains(flags, "-Z 9") {
-		test.Fatal("Dump flags should not set compression level to 9 when compressed is 'f'")
+		test.Fatal("Dump flags should not set compression level to 9 when NoCompress is 't'")
 	}
 
 	if strings.Contains(flags, "-x") {
@@ -69,7 +69,7 @@ func TestDumpDefaults(t *testing.T) {
 	}
 
 	if c.DumpConfig.NoCompress {
-		t.Fatal("dump config's compression should default to 't', but was ", c.DumpConfig.NoCompress)
+		t.Fatal("dump config's NoCompress should default to 'f', but was ", c.DumpConfig.NoCompress)
 	}
 
 	if c.DumpConfig.IncludePrivileges {
@@ -91,7 +91,7 @@ func TestDumpDefaults(t *testing.T) {
 		t.Fatal("dump config should strip '.gz' suffix, but was ", c.DumpConfig.DumpFile)
 	}
 	if c.DumpConfig.NoCompress {
-		t.Fatal("dump config should set Compress='t' if '.gz' suffix is present, but was ", c.DumpConfig.NoCompress)
+		t.Fatal("dump config should set NoCompress='f' if '.gz' suffix is present, but was ", c.DumpConfig.NoCompress)
 	}
 }
 

--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -100,8 +100,17 @@ func Load(c *Config) error {
 		return err
 	}
 
-	if c.DumpConfig.Compress {
-		sh("gunzip", []string{"-c", c.DumpConfig.GetDumpFile(), ">", c.DumpConfig.GetDumpFileRaw()})
+	fmt.Println(c.DumpConfig)
+	if c.DumpConfig.IsCompressed() {
+		dumpSQL, err := shRead("gunzip", []string{"-c", c.DumpConfig.GetDumpFile()})
+
+		file, err := os.OpenFile(c.DumpConfig.GetDumpFileRaw(), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0600)
+		if err != nil {
+			return err
+		}
+
+		file.Write(*dumpSQL)
+		file.Close()
 		defer func() { sh("rm", []string{"-f", c.DumpConfig.GetDumpFileRaw()}) }()
 	}
 

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -26,7 +26,7 @@ func globalConfig() *Config {
 		MigrationFolder: migrationFolder,
 		MigrationTable:  "schema_migrations",
 		SslMode:         "disable",
-		DumpConfig:      DumpConfig{DumpFile: dumpFile, Compress: false},
+		DumpConfig:      DumpConfig{DumpFile: dumpFile, NoCompress: true},
 	}
 }
 


### PR DESCRIPTION
🍏 📗 💚 
By default we always compress. There was an issue with negation with the `compress` flag so it had to be changed to `no-compress`.

There was also an issue with the `gz` file being read when compressed, so that has been updated to write to a brand new file that gets removed.