### PR TITLE
Gracefully exit db load when dump file is missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	app.Name = "pgmgr"
 	app.Usage = "manage your app's Postgres database"
-	app.Version = "1.1.1"
+	app.Version = "1.1.2"
 
 	var s []string
 


### PR DESCRIPTION
🍏 📗 💚 

Failing to load with `exit 1` when a dump file doesn't exist is harsh (for scripting purposes). It's more useful to fail when something actually goes wrong with loading the dump.