### PR TITLE
Use column-type from context if provided

### DIFF
--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -192,6 +192,9 @@ func (config *Config) applyArguments(ctx argumentContext) {
 	if ctx.String("migration-driver") != "" {
 		config.MigrationDriver = ctx.String("migration-driver")
 	}
+	if ctx.String("column-type") != "" {
+		config.ColumnType = ctx.String("column-type")
+	}
 	config.DumpConfig.applyArguments(ctx)
 }
 

--- a/pgmgr/config_test.go
+++ b/pgmgr/config_test.go
@@ -101,6 +101,21 @@ func TestOverlays(t *testing.T) {
 	if c.Port != 123 {
 		t.Fatal("config's port should not change, but was", c.Port)
 	}
+
+	//reset
+	c = &Config{}
+	ctx = &TestContext{StringVals: make(map[string]string)}
+
+	// should prefer the value from ctx, since
+	// it was passed-in explictly at runtime
+	c.ColumnType = "integer"
+	ctx.StringVals["column-type"] = "string"
+
+	LoadConfig(c, ctx)
+
+	if c.ColumnType != "string" {
+		t.Fatal("config's column-type should come from the context, but was", c.ColumnType)
+	}
 }
 
 func TestURL(t *testing.T) {


### PR DESCRIPTION
Use `column-type` either passed from argument or through environment variables instead of default value if no config file is provided.