### PR TITLE
Fix erroneous defaults

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	app.Name = "pgmgr"
 	app.Usage = "manage your app's Postgres database"
-	app.Version = "1.1.3"
+	app.Version = "1.1.4"
 
 	var s []string
 

--- a/main.go
+++ b/main.go
@@ -93,20 +93,20 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:   "column-type",
-			Value:  "integer",
-			Usage:  "column type to use in schema_migrations table; 'integer' or 'string'",
+			Value:  "",
+			Usage:  "column type to use in schema_migrations table; 'integer' or 'string' (default: integer)",
 			EnvVar: "PGMGR_COLUMN_TYPE",
 		},
 		cli.StringFlag{
 			Name:   "format",
-			Value:  "unix",
-			Usage:  "timestamp format for migrations; 'unix' or 'datetime'",
+			Value:  "",
+			Usage:  "timestamp format for migrations; 'unix' or 'datetime' (default: unix)",
 			EnvVar: "PGMGR_FORMAT",
 		},
 		cli.StringFlag{
 			Name:   "migration-table",
-			Value:  "schema_migrations",
-			Usage:  "table to use for storing migration status; eg 'myschema.applied_migrations'",
+			Value:  "",
+			Usage:  "table to use for storing migration status; eg 'myschema.applied_migrations' (default: schema_migrations)",
 			EnvVar: "PGMGR_MIGRATION_TABLE",
 		},
 		cli.StringFlag{
@@ -118,7 +118,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "migration-driver",
 			Value:  "",
-			Usage:  "how to apply the migrations. supported options are pq (which will execute the migration as one statement) or psql (which will use the psql binary on your system to execute each line)",
+			Usage:  "how to apply the migrations. supported options are pq (which will execute the migration as one statement) or psql (which will use the psql binary on your system to execute each line) (default: pq)",
 			EnvVar: "PGMGR_MIGRATION_DRIVER",
 		},
 		cli.BoolFlag{

--- a/pgmgr/config.go
+++ b/pgmgr/config.go
@@ -192,8 +192,14 @@ func (config *Config) applyArguments(ctx argumentContext) {
 	if ctx.String("migration-driver") != "" {
 		config.MigrationDriver = ctx.String("migration-driver")
 	}
+	if ctx.String("migration-table") != "" {
+		config.MigrationTable = ctx.String("migration-table")
+	}
 	if ctx.String("column-type") != "" {
 		config.ColumnType = ctx.String("column-type")
+	}
+	if ctx.String("format") != "" {
+		config.Format = ctx.String("format")
 	}
 	config.DumpConfig.applyArguments(ctx)
 }


### PR DESCRIPTION
Drop defaults from the CLI layer, as they always took precedence over values from the config file. That is, setting column-type: string in your JSON would no longer work, as the default value of "integer" from the CLI would always override it. This also fixes the CLI values to be applied for column format and migration table, where previously they were ignored.