### PR TITLE
Fix psql driver bug with comment-ending migrations

### DIFF
--- a/pgmgr/pgmgr.go
+++ b/pgmgr/pgmgr.go
@@ -341,11 +341,11 @@ func applyMigrationByPsql(c *Config, m Migration, direction int) error {
 
 	if direction == UP {
 		tmpfile.WriteString(
-			fmt.Sprintf(`; INSERT INTO %s (version) VALUES ('%d');`, c.quotedMigrationTable(), m.Version),
+			fmt.Sprintf("\n; INSERT INTO %s (version) VALUES ('%d');", c.quotedMigrationTable(), m.Version),
 		)
 	} else { // DOWN
 		tmpfile.WriteString(
-			fmt.Sprintf(`; DELETE FROM %s WHERE version = '%d';`, c.quotedMigrationTable(), m.Version),
+			fmt.Sprintf("\n; DELETE FROM %s WHERE version = '%d';", c.quotedMigrationTable(), m.Version),
 		)
 	}
 

--- a/pgmgr/pgmgr_test.go
+++ b/pgmgr/pgmgr_test.go
@@ -391,7 +391,7 @@ func TestMigratePsqlDriver(t *testing.T) {
 	}
 
 	if v != 2 {
-		t.Fatal("expected version 2, got ", v)
+		t.Fatal("expected version 2, got", v)
 	}
 
 	if err := psqlExec(t, `SELECT * FROM foos;`); err != nil {
@@ -404,7 +404,7 @@ func TestMigratePsqlDriver(t *testing.T) {
 
 	v, _ = Version(config)
 	if v != 1 {
-		t.Fatal("expected version 1, got ", v)
+		t.Fatal("expected version 1, got", v)
 	}
 
 	if err := Rollback(config); err != nil {
@@ -413,7 +413,7 @@ func TestMigratePsqlDriver(t *testing.T) {
 
 	v, _ = Version(config)
 	if v != -1 {
-		t.Fatal("expected version -1, got ", v)
+		t.Fatal("expected version -1, got", v)
 	}
 
 	if err := psqlExec(t, `SELECT * FROM foos;`); err == nil {
@@ -426,6 +426,29 @@ func TestMigratePsqlAddsSemicolon(t *testing.T) {
 	clearMigrationFolder(t)
 
 	writeMigration(t, "001_create_foos.up.sql", `CREATE TABLE foos (foo_id INTEGER, val BOOLEAN)`)
+
+	config := globalConfig()
+	config.MigrationDriver = "psql"
+
+	if err := Migrate(config); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := Version(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v != 1 {
+		t.Fatal("Expected migration to apply; did not -- version is still: ", v)
+	}
+}
+
+func TestMigratePsqlAddsNewline(t *testing.T) {
+	resetDB(t)
+	clearMigrationFolder(t)
+
+	writeMigration(t, "001_create_foos.up.sql", `CREATE TABLE foos (foo_id INTEGER, val BOOLEAN); --okay, all done!`)
 
 	config := globalConfig()
 	config.MigrationDriver = "psql"


### PR DESCRIPTION
A migration that ended in a comment, like:

```sql
  CREATE TABLE foos (bar INTEGER);
  -- okay, done
```

Would append its version-incrementing statement like so:

```sql
  CREATE TABLE foos (bar INTEGER);
  -- okay, done; INSERT INTO schema_migrations (version) VALUES (...);
```

Causing the version not to increment. To fix this, I'm appending a newline before the INSERT.